### PR TITLE
can create item as an owner now

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -52,6 +52,6 @@ class ItemsController < ApplicationController
   end
 
   def user_params
-    params.require(:item).require(:user).permit(:location)
+    params.require(:user).permit(:location)
   end
 end


### PR DESCRIPTION
fixed this method, not shoul create a new item. Go to /items if it shows an error. It is still tries to redirect to the show page that doesn;t work.
def user_params
    params.require(:user).permit(:location)
  end